### PR TITLE
Fix GraphEditor broken links

### DIFF
--- a/GraphEditor/GraphEditor.gd
+++ b/GraphEditor/GraphEditor.gd
@@ -174,22 +174,22 @@ func _update() -> void:
 		var state_name = str(state.name)
 		
 		if !_has_state_node(state_name):
-			var graphNode : GraphNode = state_node_scene.instantiate()
-			graphNode.name = state_name
-			graphNode.set_title(state_name)
-			graphNode.has_standalone_trigger = state.standalone_trigger != null
-			graph_edit.add_child(graphNode)
+			var graph_node : GraphNode = state_node_scene.instantiate()
+			graph_node.name = state_name
+			graph_node.set_title(state_name)
+			graph_node.has_standalone_trigger = state.standalone_trigger != null
+			graph_edit.add_child(graph_node)
 			if logs: print_debug("Add state node %s to the graph" % state_name)
 			
-			var __ = graphNode.item_rect_changed.connect(_on_state_node_item_rect_changed.bind(graphNode))
-			__ = graphNode.connection_attempt.connect(_on_state_node_connection_attempt.bind(graphNode))
-			__ = graphNode.trigger_selected.connect(_on_node_trigger_selected.bind(graphNode))
-			__ = graphNode.node_selected.connect(_on_node_selected_changed.bind(graphNode))
-			__ = graphNode.node_deselected.connect(_on_node_selected_changed.bind(graphNode))
+			var __ = graph_node.item_rect_changed.connect(_on_state_node_item_rect_changed.bind(graph_node))
+			__ = graph_node.connection_attempt.connect(_on_state_node_connection_attempt.bind(graph_node))
+			__ = graph_node.trigger_selected.connect(_on_node_trigger_selected.bind(graph_node))
+			__ = graph_node.node_selected.connect(_on_node_selected_changed.bind(graph_node))
+			__ = graph_node.node_deselected.connect(_on_node_selected_changed.bind(graph_node))
 			
-			__ = state.standalone_trigger_added.connect(Callable(graphNode,"_on_standalone_trigger_added"))
-			__ = state.standalone_trigger_removed.connect(Callable(graphNode,"_on_standalone_trigger_removed"))
-			__ = state.renamed.connect(Callable(graphNode,"_on_state_renamed").bind(state))
+			__ = state.standalone_trigger_added.connect(Callable(graph_node,"_on_standalone_trigger_added"))
+			__ = state.standalone_trigger_removed.connect(Callable(graph_node,"_on_standalone_trigger_removed"))
+			__ = state.renamed.connect(Callable(graph_node,"_on_state_renamed").bind(state))
 
 	# Update connections
 	for state in states_array:

--- a/GraphEditor/GraphEditor.gd
+++ b/GraphEditor/GraphEditor.gd
@@ -181,15 +181,15 @@ func _update() -> void:
 			graph_edit.add_child(graph_node)
 			if logs: print_debug("Add state node %s to the graph" % state_name)
 			
-			var __ = graph_node.item_rect_changed.connect(_on_state_node_item_rect_changed.bind(graph_node))
-			__ = graph_node.connection_attempt.connect(_on_state_node_connection_attempt.bind(graph_node))
-			__ = graph_node.trigger_selected.connect(_on_node_trigger_selected.bind(graph_node))
-			__ = graph_node.node_selected.connect(_on_node_selected_changed.bind(graph_node))
-			__ = graph_node.node_deselected.connect(_on_node_selected_changed.bind(graph_node))
+			graph_node.item_rect_changed.connect(_on_state_node_item_rect_changed.bind(graph_node))
+			graph_node.connection_attempt.connect(_on_state_node_connection_attempt.bind(graph_node))
+			graph_node.trigger_selected.connect(_on_node_trigger_selected.bind(graph_node))
+			graph_node.node_selected.connect(_on_node_selected_changed.bind(graph_node))
+			graph_node.node_deselected.connect(_on_node_selected_changed.bind(graph_node))
 			
-			__ = state.standalone_trigger_added.connect(Callable(graph_node,"_on_standalone_trigger_added"))
-			__ = state.standalone_trigger_removed.connect(Callable(graph_node,"_on_standalone_trigger_removed"))
-			__ = state.renamed.connect(Callable(graph_node,"_on_state_renamed").bind(state))
+			state.standalone_trigger_added.connect(Callable(graph_node,"_on_standalone_trigger_added"))
+			state.standalone_trigger_removed.connect(Callable(graph_node,"_on_standalone_trigger_removed"))
+			state.renamed.connect(Callable(graph_node,"_on_state_renamed").bind(state))
 
 	# Update connections
 	for state in states_array:

--- a/GraphEditor/GraphEditor.gd
+++ b/GraphEditor/GraphEditor.gd
@@ -187,9 +187,9 @@ func _update() -> void:
 			graph_node.node_selected.connect(_on_node_selected_changed.bind(graph_node))
 			graph_node.node_deselected.connect(_on_node_selected_changed.bind(graph_node))
 			
-			state.standalone_trigger_added.connect(Callable(graph_node,"_on_standalone_trigger_added"))
-			state.standalone_trigger_removed.connect(Callable(graph_node,"_on_standalone_trigger_removed"))
-			state.renamed.connect(Callable(graph_node,"_on_state_renamed").bind(state))
+			state.standalone_trigger_added.connect(graph_node._on_standalone_trigger_added)
+			state.standalone_trigger_removed.connect(graph_node._on_standalone_trigger_removed)
+			state.renamed.connect(graph_node._on_state_renamed.bind(state))
 
 	# Update connections
 	for state in states_array:

--- a/GraphEditor/GraphEditor.gd
+++ b/GraphEditor/GraphEditor.gd
@@ -174,21 +174,22 @@ func _update() -> void:
 		var state_name = str(state.name)
 		
 		if !_has_state_node(state_name):
-			var node = state_node_scene.instantiate()
-			node.name = state_name
-			node.set_title(state_name)
-			node.has_standalone_trigger = state.standalone_trigger != null
-			graph_edit.add_child(node)
+			var graphNode : GraphNode = state_node_scene.instantiate()
+			graphNode.name = state_name
+			graphNode.set_title(state_name)
+			graphNode.has_standalone_trigger = state.standalone_trigger != null
+			graph_edit.add_child(graphNode)
 			if logs: print_debug("Add state node %s to the graph" % state_name)
 			
-			var __ = node.connect("item_rect_changed", Callable(self,"_on_state_node_item_rect_changed").bind(node))
-			__ = node.connect("connection_attempt", Callable(self,"_on_state_node_connection_attempt").bind(node))
-			__ = node.connect("trigger_selected", Callable(self,"_on_node_trigger_selected").bind(node))
-			__ = node.connect("selected", Callable(self, "_on_node_selected_changed").bind(node))
-			__ = node.deselected.connect(Callable(self, "_on_node_selected_changed").bind(node))
-			__ = state.connect("standalone_trigger_added",Callable(node,"_on_standalone_trigger_added"))
-			__ = state.connect("standalone_trigger_removed",Callable(node,"_on_standalone_trigger_removed"))
-			__ = state.connect("renamed",Callable(node,"_on_state_renamed").bind(state))
+			var __ = graphNode.item_rect_changed.connect(_on_state_node_item_rect_changed.bind(graphNode))
+			__ = graphNode.connection_attempt.connect(_on_state_node_connection_attempt.bind(graphNode))
+			__ = graphNode.trigger_selected.connect(_on_node_trigger_selected.bind(graphNode))
+			__ = graphNode.node_selected.connect(_on_node_selected_changed.bind(graphNode))
+			__ = graphNode.node_deselected.connect(_on_node_selected_changed.bind(graphNode))
+			
+			__ = state.standalone_trigger_added.connect(Callable(graphNode,"_on_standalone_trigger_added"))
+			__ = state.standalone_trigger_removed.connect(Callable(graphNode,"_on_standalone_trigger_removed"))
+			__ = state.renamed.connect(Callable(graphNode,"_on_state_renamed").bind(state))
 
 	# Update connections
 	for state in states_array:

--- a/GraphEditor/StateGraphNode.gd
+++ b/GraphEditor/StateGraphNode.gd
@@ -3,7 +3,7 @@ extends GraphNode
 class_name StateGraphNode
 
 @onready var line = $Line2D
-@onready var trigger_button = $TriggerButton
+@onready var trigger_button : Button = $TriggerButton
 
 var drawing_line : bool = false :
 	get:
@@ -37,12 +37,12 @@ func is_selected() -> bool: return selected
 #### BUILT-IN ####
 
 func _ready() -> void:
-	connect("drawing_line_changed", Callable(self,"_on_drawing_line_changed"))
-	connect("selected", Callable(self,"_on_selected_changed"))
-	connect("deselected", Callable(self,"_on_selected_changed"))
-	connect("has_standalone_trigger_changed", Callable(self,"_on_has_standalone_trigger_changed"))
-	trigger_button.connect("pressed", Callable(self,"_on_trigger_button_pressed"))
+	drawing_line_changed.connect(_on_drawing_line_changed)
+	node_selected.connect(_on_selected_changed)
+	node_deselected.connect(_on_selected_changed)
+	has_standalone_trigger_changed.connect(_on_has_standalone_trigger_changed)
 	
+	trigger_button.pressed.connect(_on_trigger_button_pressed)
 	trigger_button.set_button_icon(get_theme_icon("Signals", "EditorIcons"))
 	trigger_button.set_visible(has_standalone_trigger)
 


### PR DESCRIPTION
# Fix Connections

## 1 - Corrections des connections suivantes:
<ol>
 <li> __ = node.connect("selected", Callable(self, "_on_node_selected_changed").bind(node)) </li>
 <li> __ = node.deselected.connect(Callable(self, "_on_node_selected_changed").bind(node)) </li>
 </ol>

## 2 - Ecriture des connections (dans les fonctions impactées) au format godot 4
Exemple:
- __ = node.connect("selected", Callable(self, "_on_node_selected_changed").bind(node))
- to =>  __ = graphNode.node_selected.connect(_on_node_selected_changed.bind(graphNode))

- Justification : permet de vérifier la présence des signaux à connecter pendant le codage